### PR TITLE
CD: Temporarily disable e2e tests in CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,4 @@ jobs:
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       go-version: 1.24.1
       golangci-lint-version: 1.64.2
+      run-playwright: false


### PR DESCRIPTION
Temporarily disable e2e tests in CD to debug publishing/hash mismatch issues more easily.