### PR TITLE
Internationalisation: don't load plugin translations in test environment

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -5,11 +5,9 @@ import { PromQueryEditorByApp, PrometheusDatasource, PromCheatSheet, loadResourc
 import { ConfigEditor } from './configuration/ConfigEditor';
 import pluginJson from './plugin.json';
 
-// top level await is fine in our bundled code, but not in our test environment (yet)
-// TODO remove this when our test environment can handle top level await
-if (process.env.NODE_ENV === 'test') {
-  initPluginTranslations(pluginJson.id, [loadPrometheusResources]);
-} else {
+// don't load plugin translations in test environments
+// we don't use them anyway, and top-level await won't work currently in jest
+if (process.env.NODE_ENV !== 'test') {
   await initPluginTranslations(pluginJson.id, [loadPrometheusResources]);
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,7 +5,13 @@ import { PromQueryEditorByApp, PrometheusDatasource, PromCheatSheet, loadResourc
 import { ConfigEditor } from './configuration/ConfigEditor';
 import pluginJson from './plugin.json';
 
-initPluginTranslations(pluginJson.id, [loadPrometheusResources]);
+// top level await is fine in our bundled code, but not in our test environment (yet)
+// TODO remove this when our test environment can handle top level await
+if (process.env.NODE_ENV === 'test') {
+  initPluginTranslations(pluginJson.id, [loadPrometheusResources]);
+} else {
+  await initPluginTranslations(pluginJson.id, [loadPrometheusResources]);
+}
 
 export const plugin = new DataSourcePlugin(PrometheusDatasource)
   .setQueryEditor(PromQueryEditorByApp)


### PR DESCRIPTION
- don't load plugin translations in test environment
- we don't use them anyway, and top-level await won't currently work in jest environment

For https://github.com/grafana/grafana/issues/107039