### PR TITLE
Update release workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,5 @@
   },
   "engines": {
     "node": ">=20"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }


### PR DESCRIPTION
Since migrating our release workflow to GHA new releases have not been properly published. This PR updates the workflow configuration by setting `github-draft-release` to false, ensuring that releases are published correctly moving forward.