### PR TITLE
chore: update plugin-ci-workflows to v8.0.1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         environment: [dev, ops, prod]
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v6.1.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v6.1.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Updates `grafana/plugin-ci-workflows` reusable workflows to the target version.
- This brings CI/CD pipelines in line with the latest plugin-ci-workflows release.

## Test plan
- [ ] Verify CI passes on this PR